### PR TITLE
Change pr_url parameter search on cancel builds in case the parameter is repeated

### DIFF
--- a/src/main/java/com/elasticbox/jenkins/triggers/github/PullRequestBuildHandler.java
+++ b/src/main/java/com/elasticbox/jenkins/triggers/github/PullRequestBuildHandler.java
@@ -439,13 +439,13 @@ public class PullRequestBuildHandler implements IBuildHandler {
         if (parameters == null) {
             return false;
         }
-
-        final ParameterValue pr_url = parameters.getParameter("PR_URL");
-        if (pr_url == null) {
-            return false;
+        for (ParameterValue parameter: parameters.getParameters()) {
+            if ("PR_URL".equals(parameter.getName()) && pullRequestUrl.equals(parameter.getValue())) {
+                return true;
+            }
         }
 
-        return pullRequestUrl.equals(pr_url.getValue() );
+        return false;
     }
 
     void cancelBuilds(PullRequestData pullRequestData) {


### PR DESCRIPTION
@HectorGarciaAlvarez @gsanchezu This is only a guess but i think the order of the parameters could be messing with the cancel build